### PR TITLE
Added Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,24 @@
 
 ## Requirements ##
 
-[Nette Framework 2.0.3](http://nette.org) or higher and PHP 5.3 or higher.
+[Nette Framework 2.1](http://nette.org) or higher and PHP 5.3 or higher.
 
 ## Documentation ##
 Simple DebugBar to show contents of session.
 
 ## Examples ##
 
-To load SessionPanel into the DebugBar by insert following code into config.neon
-
+To load SessionPanel into the DebugBar insert following code into config.neon.
 ```neon
-nette:
-	debugger:
-		bar:
-			- Kdyby\Diagnostics\SessionPanel\SessionPanel
+extensions:
+	debugger.session: Kdyby\Diagnostics\SessionPanel\SessionPanelExtension
 ```
 
-You can also specify section to hide in debugbar by add setup section in service definition.
-
+You can also specify a section to hide in the DebugBar by add setup section in service definition.
 ```neon
 services:
-	sessionPanel:
-		class: Kdyby\Diagnostics\SessionPanel\SessionPanel
+	debugger.session.panel:
 		setup:
+			- hideSection('Nette.Http.UserStorage/')
 			- hideSection('Nette.Forms.Form/CSRF')
-
-nette:
-	debugger:
-		bar:
-			- @sessionPanel
 ```

--- a/libs/Kdyby/Diagnostics/SessionPanel/SessionPanelExtension.php
+++ b/libs/Kdyby/Diagnostics/SessionPanel/SessionPanelExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kdyby\Diagnostics\SessionPanel;
+
+use Nette;
+
+/**
+ * @author Jáchym Toušek <enumag@gmail.com>
+ */
+class SessionPanelExtension extends Nette\Config\CompilerExtension
+{
+
+	public function loadConfiguration()
+	{
+		$builder = $this->getContainerBuilder();
+		if ($builder->parameters['debugMode']) {
+			$builder->addDefinition($this->prefix('panel'))
+				->setClass('Kdyby\Diagnostics\SessionPanel\SessionPanel');
+		}
+	}
+
+	public function afterCompile(Nette\PhpGenerator\ClassType $class)
+	{
+		$builder = $this->getContainerBuilder();
+		if ($builder->parameters['debugMode']) {
+			$class->methods['initialize']->addBody($builder->formatPhp(
+				'Nette\Diagnostics\Debugger::$bar->addPanel(?);',
+				Nette\Config\Compiler::filterArguments(array(new Nette\DI\Statement($this->prefix('@panel'))))
+			));
+		}
+	}
+
+}


### PR DESCRIPTION
Great! One more commit to merge and I won't need a separate version anymore. :-)

Nette\Diagnostics\Dumper is not in 2.0, so we need to change the required version in readme.
