### PR TITLE
Add session and httpRequest services

### DIFF
--- a/src/Kdyby/SessionPanel/DI/SessionPanelExtension.php
+++ b/src/Kdyby/SessionPanel/DI/SessionPanelExtension.php
@@ -32,7 +32,7 @@ class SessionPanelExtension extends Nette\DI\CompilerExtension
 		$builder = $this->getContainerBuilder();
 		if ($builder->parameters['debugMode']) {
 			$builder->addDefinition($this->prefix('panel'))
-				->setClass('Kdyby\SessionPanel\Diagnostics\SessionPanel');
+				->setClass('Kdyby\SessionPanel\Diagnostics\SessionPanel', array('@session', '@httpRequest'));
 		}
 	}
 


### PR DESCRIPTION
....because if I use other extension which modify httpRequest or session (for example https://github.com/drahak/Restful/blob/master/src/Drahak/Restful/DI/RestfulExtension.php#L163-L164) my application is aborted with:
 _Service '0.panel': No service of type Nette\Http\Request found. Make sure the type hint in Kdyby\SessionPanel\Diagnostics\SessionPanel::__construct() is written correctly and service of this type is registered_
