### PR TITLE
fix for Nette 2.4

### DIFF
--- a/src/Kdyby/SessionPanel/Diagnostics/SessionPanel.php
+++ b/src/Kdyby/SessionPanel/Diagnostics/SessionPanel.php
@@ -125,7 +125,7 @@ class SessionPanel extends Nette\Object implements Tracy\IBarPanel
 				return (string) $url;
 			},
 			'sections' => $this->createSessionIterator(),
-			'sessionMaxTime' => $this->session->options['gc_maxlifetime'],
+			'sessionMaxTime' => $this->session->getOptions()['gc_maxlifetime'],
 		));
 	}
 
@@ -153,7 +153,7 @@ class SessionPanel extends Nette\Object implements Tracy\IBarPanel
 
 			foreach ($_SESSION as $sectionName => $data) {
 				if ($sectionName === '__NF') continue;
-	
+
 				$sections[] = (object) array(
 					'title' => $sectionName,
 					'data' => $data,
@@ -173,7 +173,7 @@ class SessionPanel extends Nette\Object implements Tracy\IBarPanel
 	protected function createNetteSessionIterator()
 	{
 		$sections = $this->session->getIterator();
-		
+
 		return new Mapper($sections, function ($sectionName) {
 			$data = $_SESSION['__NF']['DATA'][$sectionName];
 
@@ -272,6 +272,6 @@ class SessionPanel extends Nette\Object implements Tracy\IBarPanel
 	{
 		return method_exists('Tracy\Debugger', 'getBar') ? Tracy\Debugger::getBar() : Tracy\Debugger::$bar;
 	}
-	
+
 
 }


### PR DESCRIPTION
V aktuální verzi Nette\Http\Session je $options private a zde došlo k odstranění i anotací https://github.com/nette/http/commit/689322cfb42d379a38b554baaa559406077fb119#diff-0f7ea695bfce9d833eb7dbf3fc999244L20 takže to aktuálně nefungovalo. 

![error](https://cloud.githubusercontent.com/assets/12897610/19767879/2e2b31e6-9c55-11e6-9e26-156127884c86.png)
